### PR TITLE
Update ESModel.js

### DIFF
--- a/src/ESModel.js
+++ b/src/ESModel.js
@@ -220,7 +220,7 @@ export class ESModel {
       query: {
         match_all: {}
       },
-      size: 100
+      size: process.env.ES_SCAN_SIZE || 100
     }
 
     Client.search({


### PR DESCRIPTION
Added change in scan size  size: process.env.ES_SCAN_SIZE || 100  
because size limit is 100 set as default that's why we are not able to fetch all files.